### PR TITLE
feat: replace emoji icons with PNG assets in bottom navigation bar

### DIFF
--- a/apps/web/components/BottomNavBar.tsx
+++ b/apps/web/components/BottomNavBar.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 
 export function BottomNavBar() {
   const pathname = usePathname();
 
   const tabs = [
-    { name: 'microorganismTest', path: '/microorganismTest', label: '미생물 검사', icon: '🔬' },
-    { name: 'record', path: '/record', label: '기록', icon: '📝' },
-    { name: 'home', path: '/', label: '홈', icon: '🏠' },
-    { name: 'shopping', path: '/shopping', label: '쇼핑', icon: '🛒' },
-    { name: 'mypage', path: '/myPage', label: '마이', icon: '👤' },
+    { name: 'microorganismTest', path: '/microorganismTest', label: '미생물 검사', icon: '/BottomNav/tab-microorganismTest.png' },
+    { name: 'record', path: '/record', label: '기록', icon: '/BottomNav/tab-record.png' },
+    { name: 'home', path: '/', label: '홈', icon: '/BottomNav/tab-home.png' },
+    { name: 'shopping', path: '/shopping', label: '쇼핑', icon: '/BottomNav/tab-shopping.png' },
+    { name: 'mypage', path: '/myPage', label: '마이', icon: '/BottomNav/tab-mypage.png' },
   ];
 
   return (
@@ -31,9 +32,14 @@ export function BottomNavBar() {
               href={tab.path}
               className="flex flex-col items-center justify-center flex-1 py-2 active:scale-95 transition-transform"
             >
-              <span className={`text-2xl mb-1 transition-opacity ${isActive ? 'opacity-100' : 'opacity-60'}`}>
-                {tab.icon}
-              </span>
+              <div className={`mb-1 transition-opacity ${isActive ? 'opacity-100' : 'opacity-60'}`}>
+                <Image
+                  src={tab.icon}
+                  alt={tab.label}
+                  width={24}
+                  height={24}
+                />
+              </div>
               <span
                 className={`text-xs transition-colors ${
                   isActive ? 'text-[#FF6B6B] font-semibold' : 'text-gray-500'


### PR DESCRIPTION
- Use /BottomNav/tab-*.png images instead of emoji
- Add Next.js Image component for optimized loading
- Maintain opacity transition for active/inactive states
- Icon size: 24x24px

## #️⃣연관된 이슈

ex) #이슈번호, #이슈번호

📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
[ ]
[ ]
[ ]

스크린샷 (선택)
💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?