### PR TITLE
Add safe line to top of screen

### DIFF
--- a/packages/shared/src/components/AppBar/index.tsx
+++ b/packages/shared/src/components/AppBar/index.tsx
@@ -19,7 +19,7 @@ interface AppBarProps {
 const AppBar = ({ leftContent, text, rightContent, bgColor = 'bg-background' }: AppBarProps) => {
   return (
     <div
-      className={`fixed top-0 left-auto right-auto z-100 flex justify-between items-center border-none px-4 pb-2 w-full h-[32px] ${bgColor}`}
+      className={`fixed top-0 left-auto right-auto z-100 flex justify-between items-center border-none px-4 pb-2 w-full min-h-[32px] ${bgColor}`}
       style={{
         paddingTop: 'calc(1rem + env(safe-area-inset-top))'
       }}


### PR DESCRIPTION
- Changed h-[32px] to min-h-[32px] to allow AppBar to expand with safe area padding
- Fixes issue where header content was being cut off on devices with notches
- AppBar now properly accommodates calc(1rem + env(safe-area-inset-top)) padding

## #️⃣연관된 이슈

ex) #이슈번호, #이슈번호

📝작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
[ ]
[ ]
[ ]

스크린샷 (선택)
💬리뷰 요구사항(선택)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?